### PR TITLE
V0.7.1

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
     - name: Checkout sources
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
 
@@ -53,7 +53,7 @@ jobs:
 
     steps:
     - name: Checkout sources
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
 

--- a/.github/workflows/run-examples.yml
+++ b/.github/workflows/run-examples.yml
@@ -28,7 +28,7 @@ jobs:
             python-version: [3.7, 3.8, 3.9, 3.10, 3.11]
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -102,7 +102,6 @@ jobs:
 
       - name: CUDA examples
         if: runner.os == 'Linux'
-        continue-on-error: true
         run: |
           wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-keyring_1.0-1_all.deb
           sudo dpkg -i cuda-keyring_1.0-1_all.deb
@@ -111,34 +110,39 @@ jobs:
           PATH+=:/usr/local/cuda/bin
 
           # Examples may fail because there's no GPU
-          cargo run --features=cuda --example fee_cuda 10
-          cargo run --features=cuda --example analytic_cuda 10
-          cargo run --features=cuda,gpu-single --example fee_cuda 10
-          cargo run --features=cuda,gpu-single --example analytic_cuda 10
+          cargo build --features=cuda --example fee_cuda
+          ./target/debug/examples/fee_cuda 10 || true
+          cargo build --features=cuda --example analytic_cuda
+          ./target/debug/examples/analytic_cuda 10 || true
+          cargo build --features=cuda,gpu-single --example fee_cuda
+          ./target/debug/examples/fee_cuda 10 || true
+          cargo build --features=cuda,gpu-single --example analytic_cuda
+          ./target/debug/examples/analytic_cuda 10 || true
 
           cargo build --release --features=cuda
           gcc -O3 examples/fee_gpu.c -o fee_cuda -I ./include/ -L ./target/release/ -l mwa_hyperbeam
-          LD_LIBRARY_PATH=$LD_LIBRARY_PATH:./target/release/ ./fee_cuda mwa_full_embedded_element_pattern.h5
+          LD_LIBRARY_PATH=$LD_LIBRARY_PATH:./target/release/ ./fee_cuda mwa_full_embedded_element_pattern.h5 || true
           nvcc -O3 examples/fee_cuda_device.cu -o fee_cuda_device -I ./include/ -L ./target/release/ -l mwa_hyperbeam
-          LD_LIBRARY_PATH=$LD_LIBRARY_PATH:./target/release ./fee_cuda_device mwa_full_embedded_element_pattern.h5
+          LD_LIBRARY_PATH=$LD_LIBRARY_PATH:./target/release ./fee_cuda_device mwa_full_embedded_element_pattern.h5 || true
           gcc -O3 examples/analytic_gpu.c -o analytic_cuda -I ./include/ -L ./target/release/ -l mwa_hyperbeam
-          LD_LIBRARY_PATH=$LD_LIBRARY_PATH:./target/release/ ./analytic_cuda
+          LD_LIBRARY_PATH=$LD_LIBRARY_PATH:./target/release/ ./analytic_cuda || true
           nvcc -O3 examples/analytic_cuda_device.cu -o analytic_cuda_device -I ./include/ -L ./target/release/ -l mwa_hyperbeam
-          LD_LIBRARY_PATH=$LD_LIBRARY_PATH:./target/release ./analytic_cuda_device
+          LD_LIBRARY_PATH=$LD_LIBRARY_PATH:./target/release ./analytic_cuda_device || true
 
           cargo build --release --features=cuda,gpu-single
           gcc -O3 -D SINGLE examples/fee_gpu.c -o fee_cuda -I ./include/ -L ./target/release/ -l mwa_hyperbeam
-          LD_LIBRARY_PATH=$LD_LIBRARY_PATH:./target/release/ ./fee_cuda mwa_full_embedded_element_pattern.h5
+          LD_LIBRARY_PATH=$LD_LIBRARY_PATH:./target/release/ ./fee_cuda mwa_full_embedded_element_pattern.h5 || true
           nvcc -O3 -D SINGLE examples/fee_cuda_device.cu -o fee_cuda_device -I ./include/ -L ./target/release/ -l mwa_hyperbeam
-          LD_LIBRARY_PATH=$LD_LIBRARY_PATH:./target/release ./fee_cuda_device mwa_full_embedded_element_pattern.h5
+          LD_LIBRARY_PATH=$LD_LIBRARY_PATH:./target/release ./fee_cuda_device mwa_full_embedded_element_pattern.h5 || true
           gcc -O3 -D SINGLE examples/analytic_gpu.c -o analytic_cuda -I ./include/ -L ./target/release/ -l mwa_hyperbeam
-          LD_LIBRARY_PATH=$LD_LIBRARY_PATH:./target/release/ ./analytic_cuda
+          LD_LIBRARY_PATH=$LD_LIBRARY_PATH:./target/release/ ./analytic_cuda || true
           nvcc -O3 -D SINGLE examples/analytic_cuda_device.cu -o analytic_cuda_device -I ./include/ -L ./target/release/ -l mwa_hyperbeam
-          LD_LIBRARY_PATH=$LD_LIBRARY_PATH:./target/release ./analytic_cuda_device
+          LD_LIBRARY_PATH=$LD_LIBRARY_PATH:./target/release ./analytic_cuda_device || true
 
+          . ./venv/bin/activate
           maturin develop -b pyo3 --features=python,cuda
-          LD_LIBRARY_PATH=$LD_LIBRARY_PATH:./target/release/ ./examples/fee_gpu.py mwa_full_embedded_element_pattern.h5
-          LD_LIBRARY_PATH=$LD_LIBRARY_PATH:./target/release/ ./examples/analytic_gpu.py
+          LD_LIBRARY_PATH=$LD_LIBRARY_PATH:./target/release/ ./examples/fee_gpu.py mwa_full_embedded_element_pattern.h5 || true
+          LD_LIBRARY_PATH=$LD_LIBRARY_PATH:./target/release/ ./examples/analytic_gpu.py || true
           maturin develop -b pyo3 --features=python,cuda,gpu-single
-          LD_LIBRARY_PATH=$LD_LIBRARY_PATH:./target/release/ ./examples/fee_gpu.py mwa_full_embedded_element_pattern.h5
-          LD_LIBRARY_PATH=$LD_LIBRARY_PATH:./target/release/ ./examples/analytic_gpu.py
+          LD_LIBRARY_PATH=$LD_LIBRARY_PATH:./target/release/ ./examples/fee_gpu.py mwa_full_embedded_element_pattern.h5 || true
+          LD_LIBRARY_PATH=$LD_LIBRARY_PATH:./target/release/ ./examples/analytic_gpu.py || true

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -30,7 +30,7 @@ jobs:
             python-version: [3.7, 3.8, 3.9, 3.10, 3.11]
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.7.1] - unreleased
+## [0.7.1] - 2024-01-19
 ### Fixed
+- A (seemingly rare) race condition in FEE GPU code.
 - examples/analytic_cuda_device.cu wasn't complete.
 
 ## [0.7.0] - 2023-10-31

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.1] - unreleased
+### Fixed
+- examples/analytic_cuda_device.cu wasn't complete.
+
 ## [0.7.0] - 2023-10-31
 ### Added
 - Expose Rust function `fix_amps_ndarray`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -786,7 +786,7 @@ dependencies = [
 
 [[package]]
 name = "mwa_hyperbeam"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "approx",
  "cbindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mwa_hyperbeam"
-version = "0.7.0"
+version = "0.7.1"
 authors = [
     "Christopher H. Jordan <christopherjordan87@gmail.com>",
     "Jack L. B. Line <jack.line@curtin.edu.au>",

--- a/examples/analytic_cuda_device.cu
+++ b/examples/analytic_cuda_device.cu
@@ -113,7 +113,11 @@ int main(int argc, char *argv[]) {
     AnalyticBeam *beam;
     char rts_style = 1;                  // 1 or RTS style, 0 for mwa_pb
     double *dipole_height_metres = NULL; // Point to a valid float if you want a custom height
-    if (new_analytic_beam(rts_style, dipole_height_metres, &beam))
+    // Point to a valid int if you want a custom number of bowties per row. You
+    // almost certainly want this to be 4, unless you're simulating the CRAM
+    // tile.
+    uint8_t *bowties_per_row = NULL;
+    if (new_analytic_beam(rts_style, dipole_height_metres, bowties_per_row, &beam))
         handle_hyperbeam_error(__FILE__, __LINE__, "new_analytic_beam");
 
     // Set up our telescope array. Here, we are using three tiles, but there are

--- a/src/analytic/gpu/mod.rs
+++ b/src/analytic/gpu/mod.rs
@@ -67,7 +67,7 @@ impl AnalyticBeamGpu {
             return Err(AnalyticBeamError::IncorrectDelaysArrayColLength {
                 rows: delays_array.len_of(Axis(0)),
                 num_delays: delays_array.len_of(Axis(1)),
-                expected: usize::from(num_bowties),
+                expected: num_bowties,
             });
         }
         if amps_array.len_of(Axis(1)) != num_bowties

--- a/src/fee/gpu/double.rs
+++ b/src/fee/gpu/double.rs
@@ -207,7 +207,7 @@ fn bindgen_test_layout_FEECoeffs() {
     );
 }
 extern "C" {
-    pub fn gpu_calc_jones(
+    pub fn gpu_fee_calc_jones(
         d_azs: *const f64,
         d_zas: *const f64,
         num_directions: ::std::os::raw::c_int,

--- a/src/fee/gpu/fee.h
+++ b/src/fee/gpu/fee.h
@@ -28,9 +28,9 @@ typedef struct FEECoeffs {
     const unsigned char n_max;
 } FEECoeffs;
 
-const char *gpu_calc_jones(const FLOAT *d_azs, const FLOAT *d_zas, int num_directions, const FEECoeffs *d_coeffs,
-                           int num_coeffs, const void *d_norm_jones, const FLOAT *d_latitude_rad, const int iau_reorder,
-                           void *d_results);
+const char *gpu_fee_calc_jones(const FLOAT *d_azs, const FLOAT *d_zas, int num_directions, const FEECoeffs *d_coeffs,
+                               int num_coeffs, const void *d_norm_jones, const FLOAT *d_latitude_rad,
+                               const int iau_reorder, void *d_results);
 
 #ifdef __cplusplus
 } // extern "C"
@@ -409,9 +409,9 @@ __global__ void fee_kernel(const FEECoeffs coeffs, const FLOAT *azs, const FLOAT
     }
 }
 
-extern "C" const char *gpu_calc_jones(const FLOAT *d_azs, const FLOAT *d_zas, int num_directions,
-                                      const FEECoeffs *d_coeffs, int num_coeffs, const void *d_norm_jones,
-                                      const FLOAT *d_latitude_rad, const int iau_order, void *d_results) {
+extern "C" const char *gpu_fee_calc_jones(const FLOAT *d_azs, const FLOAT *d_zas, int num_directions,
+                                          const FEECoeffs *d_coeffs, int num_coeffs, const void *d_norm_jones,
+                                          const FLOAT *d_latitude_rad, const int iau_order, void *d_results) {
     dim3 gridDim, blockDim;
     blockDim.x = warpSize;
     gridDim.x = (int)ceil((double)num_directions / (double)blockDim.x);

--- a/src/fee/gpu/mod.rs
+++ b/src/fee/gpu/mod.rs
@@ -478,7 +478,7 @@ impl FEEBeamGpu {
 
         // The return value is a pointer to a CUDA/HIP error string. If it's null
         // then everything is fine.
-        let error_message_ptr = gpu_calc_jones(
+        let error_message_ptr = gpu_fee_calc_jones(
             d_az_rad,
             d_za_rad,
             num_directions,
@@ -498,7 +498,7 @@ impl FEEBeamGpu {
             let error_message = CStr::from_ptr(error_message_ptr)
                 .to_str()
                 .unwrap_or("<cannot read GPU error string>");
-            let our_error_str = format!("fee.h:gpu_calc_jones failed with: {error_message}");
+            let our_error_str = format!("fee.h:gpu_fee_calc_jones failed with: {error_message}");
             Err(FEEBeamError::Gpu(GpuError::Kernel {
                 msg: our_error_str.into(),
                 file: file!(),

--- a/src/fee/gpu/mod.rs
+++ b/src/fee/gpu/mod.rs
@@ -394,15 +394,19 @@ impl FEEBeamGpu {
             let d_zas = DevicePointer::copy_to_device(&zas)?;
 
             // Allocate the latitude if we have to.
-            let d_latitude_rad = latitude_rad
-                .map(|f| DevicePointer::copy_to_device(&[f as GpuFloat]))
-                .transpose()?;
+            let d_latitude_rad = match latitude_rad {
+                Some(f) => DevicePointer::copy_to_device(&[f as GpuFloat])?,
+
+                // This won't allocate and accessing the pointer will give a
+                // null ptr.
+                None => DevicePointer::default(),
+            };
 
             self.calc_jones_device_pair_inner(
                 d_azs.get(),
                 d_zas.get(),
                 azels.len().try_into().expect("much fewer than i32::MAX"),
-                d_latitude_rad.map(|p| p.get()).unwrap_or(std::ptr::null()),
+                d_latitude_rad.get(),
                 iau_reorder,
                 d_results.get_mut() as *mut std::ffi::c_void,
             )?;
@@ -433,15 +437,19 @@ impl FEEBeamGpu {
             let d_zas = DevicePointer::copy_to_device(za_rad)?;
 
             // Allocate the latitude if we have to.
-            let d_latitude_rad = latitude_rad
-                .map(|f| DevicePointer::copy_to_device(&[f as GpuFloat]))
-                .transpose()?;
+            let d_latitude_rad = match latitude_rad {
+                Some(f) => DevicePointer::copy_to_device(&[f as GpuFloat])?,
+
+                // This won't allocate and accessing the pointer will give a
+                // null ptr.
+                None => DevicePointer::default(),
+            };
 
             self.calc_jones_device_pair_inner(
                 d_azs.get(),
                 d_zas.get(),
                 az_rad.len().try_into().expect("much fewer than i32::MAX"),
-                d_latitude_rad.map(|p| p.get()).unwrap_or(std::ptr::null()),
+                d_latitude_rad.get(),
                 iau_reorder,
                 d_results.get_mut() as *mut std::ffi::c_void,
             )?;

--- a/src/fee/gpu/single.rs
+++ b/src/fee/gpu/single.rs
@@ -207,7 +207,7 @@ fn bindgen_test_layout_FEECoeffs() {
     );
 }
 extern "C" {
-    pub fn gpu_calc_jones(
+    pub fn gpu_fee_calc_jones(
         d_azs: *const f32,
         d_zas: *const f32,
         num_directions: ::std::os::raw::c_int,

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -14,7 +14,7 @@ use std::{
 };
 
 thread_local! {
-    static LAST_ERROR: RefCell<Option<String>> = RefCell::new(None);
+    static LAST_ERROR: RefCell<Option<String>> = const { RefCell::new(None) };
 }
 
 /// Update the most recent error, clearing whatever may have been there before.

--- a/src/update_rust_bindings.sh
+++ b/src/update_rust_bindings.sh
@@ -14,7 +14,7 @@ for PRECISION in SINGLE DOUBLE; do
     echo "Generating bindings for ${LOWER_CASE}-precision GPU code"
 
     bindgen "${SCRIPTPATH}"/fee/gpu/fee.h \
-        --allowlist-function "gpu_calc_jones.*" \
+        --allowlist-function "gpu_fee_calc_jones.*" \
         --allowlist-type "FEECoeffs" \
         -- -D BINDGEN -D "${PRECISION}" \
         -I "${SCRIPTPATH}"/gpu_common/ \


### PR DESCRIPTION
Have a look at this Dev.

FWIW, this seems to work fine on sirius (CUDA) and my home desktop (HIP; ROCm 5.7.1). I use a command like

```bash
while cargo test --features=hdf5-static,hip,gpu-single --release; do; done
```

to help shake out the races.

I played around with trying to make `DevicePointer` less prone to mistakes, but couldn't really find something satisfying. The issue is that raw pointer types in Rust don't have lifetimes, and we really want them to have lifetimes. You could make the `get` and `get_mut` methods on `DevicePointer` return references to the internal pointer, but then the API is a bit clunky, and I'm not sure it's worth it. I'll leave that with you.