### PR TITLE
Consolidate beam calc functions with generics

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -35,9 +35,8 @@ fn fee(c: &mut Criterion) {
         let iau_order = true;
         b.iter(|| {
             let beam = FEEBeam::new("mwa_full_embedded_element_pattern.h5").unwrap();
-            beam.calc_jones_pair(
-                az,
-                za,
+            beam.calc_jones(
+                (az, za),
                 freq,
                 &delays,
                 &amps,
@@ -60,9 +59,8 @@ fn fee(c: &mut Criterion) {
         let iau_order = true;
         let beam = FEEBeam::new("mwa_full_embedded_element_pattern.h5").unwrap();
         b.iter(|| {
-            beam.calc_jones_pair(
-                az,
-                za,
+            beam.calc_jones(
+                (az, za),
                 freq,
                 &delays,
                 &amps,
@@ -86,9 +84,8 @@ fn fee(c: &mut Criterion) {
         let iau_order = true;
         let beam = FEEBeam::new("mwa_full_embedded_element_pattern.h5").unwrap();
         // Prime the cache.
-        beam.calc_jones_pair(
-            az,
-            za,
+        beam.calc_jones(
+            (az, za),
             freq,
             &delays,
             &amps,
@@ -98,9 +95,8 @@ fn fee(c: &mut Criterion) {
         )
         .unwrap();
         b.iter(|| {
-            beam.calc_jones_pair(
-                az,
-                za,
+            beam.calc_jones(
+                (az, za),
                 freq,
                 &delays,
                 &amps,
@@ -128,9 +124,8 @@ fn fee(c: &mut Criterion) {
         let iau_order = true;
         let beam = FEEBeam::new("mwa_full_embedded_element_pattern.h5").unwrap();
         // Prime the cache.
-        beam.calc_jones_pair(
-            az[0],
-            za[0],
+        beam.calc_jones(
+            (az[0], za[0]),
             freq,
             &delays,
             &amps,
@@ -140,9 +135,8 @@ fn fee(c: &mut Criterion) {
         )
         .unwrap();
         b.iter(|| {
-            beam.calc_jones_array_pair(
-                &az,
-                &za,
+            beam.calc_jones_array(
+                (&az, &za),
                 freq,
                 &delays,
                 &amps,
@@ -172,9 +166,8 @@ fn fee(c: &mut Criterion) {
         let iau_order = true;
         let beam = FEEBeam::new("mwa_full_embedded_element_pattern.h5").unwrap();
         // Prime the cache.
-        beam.calc_jones_pair(
-            az[0],
-            za[0],
+        beam.calc_jones(
+            (az[0], za[0]),
             freq,
             &delays,
             &amps,
@@ -187,9 +180,8 @@ fn fee(c: &mut Criterion) {
             az.par_iter()
                 .zip(za.par_iter())
                 .map(|(&a, &z)| {
-                    beam.calc_jones_pair(
-                        a,
-                        z,
+                    beam.calc_jones(
+                        (a, z),
                         freq,
                         &delays,
                         &amps,
@@ -253,9 +245,8 @@ fn fee(c: &mut Criterion) {
     c.bench_function("calc_jones_array 100000 dirs", |b| {
         let beam = FEEBeam::new("mwa_full_embedded_element_pattern.h5").unwrap();
         // Prime the cache.
-        beam.calc_jones_pair(
-            az_double[0],
-            za_double[0],
+        beam.calc_jones(
+            (az_double[0], za_double[0]),
             freqs[0],
             delays.as_slice().unwrap(),
             amps.as_slice().unwrap(),
@@ -265,9 +256,8 @@ fn fee(c: &mut Criterion) {
         )
         .unwrap();
         b.iter(|| {
-            beam.calc_jones_array_pair(
-                &az_double,
-                &za_double,
+            beam.calc_jones_array(
+                (&az_double, &za_double),
                 freqs[0],
                 delays.as_slice().unwrap(),
                 amps.as_slice().unwrap(),

--- a/build.rs
+++ b/build.rs
@@ -314,7 +314,7 @@ mod gpu {
             };
 
             for arch in arches {
-                hip_target.flag(&format!("--offload-arch={arch}"));
+                hip_target.flag(format!("--offload-arch={arch}"));
             }
 
             match env::var("DEBUG").as_deref() {

--- a/examples/analytic_cuda.rs
+++ b/examples/analytic_cuda.rs
@@ -55,8 +55,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Set up the directions to test. The type depends on the GPU precision.
     let mut azels = Vec::with_capacity(num_directions);
     for i in 0..num_directions {
-        let az = 0.4 + 0.3 * PI * (i / num_directions) as f64;
-        let za = 0.3 + 0.4 * FRAC_PI_2 * (i / num_directions) as f64;
+        let az = 0.4 + 0.3 * PI * i as f64 / num_directions as f64;
+        let za = 0.3 + 0.4 * FRAC_PI_2 * i as f64 / num_directions as f64;
         azels.push(AzEl::from_radians(az, FRAC_PI_2 - za));
     }
 

--- a/examples/analytic_hip.rs
+++ b/examples/analytic_hip.rs
@@ -89,6 +89,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         norm_to_zenith,
     )?;
 
+    #[allow(clippy::useless_conversion)]
     let diff = jones[(0, 0, 0)] - Jones::<GpuFloat>::from(jones_cpu);
 
     println!("Difference between first GPU and CPU Jones matrices");

--- a/examples/analytic_hip.rs
+++ b/examples/analytic_hip.rs
@@ -55,8 +55,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Set up the directions to test. The type depends on the GPU precision.
     let mut azels = Vec::with_capacity(num_directions);
     for i in 0..num_directions {
-        let az = 0.4 + 0.3 * PI * (i / num_directions) as f64;
-        let za = 0.3 + 0.4 * FRAC_PI_2 * (i / num_directions) as f64;
+        let az = 0.4 + 0.3 * PI * i as f64 / num_directions as f64;
+        let za = 0.3 + 0.4 * FRAC_PI_2 * i as f64 / num_directions as f64;
         azels.push(AzEl::from_radians(az, FRAC_PI_2 - za));
     }
 

--- a/examples/fee_cuda.rs
+++ b/examples/fee_cuda.rs
@@ -59,8 +59,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Set up the directions to test. The type depends on the GPU precision.
     let mut azels = Vec::with_capacity(num_directions);
     for i in 0..num_directions {
-        let az = 0.4 + 0.3 * PI * (i / num_directions) as f64;
-        let za = 0.3 + 0.4 * FRAC_PI_2 * (i / num_directions) as f64;
+        let az = 0.4 + 0.3 * PI * i as f64 / num_directions as f64;
+        let za = 0.3 + 0.4 * FRAC_PI_2 * i as f64 / num_directions as f64;
         azels.push(AzEl::from_radians(az, FRAC_PI_2 - za));
     }
 

--- a/examples/fee_hip.rs
+++ b/examples/fee_hip.rs
@@ -95,6 +95,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         iau_order,
     )?;
 
+    #[allow(clippy::useless_conversion)]
     let diff = jones[(0, 0, 0)] - Jones::<GpuFloat>::from(jones_cpu);
 
     println!("Difference between first GPU and CPU Jones matrices");

--- a/examples/fee_hip.rs
+++ b/examples/fee_hip.rs
@@ -59,8 +59,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Set up the directions to test. The type depends on the GPU precision.
     let mut azels = Vec::with_capacity(num_directions);
     for i in 0..num_directions {
-        let az = 0.4 + 0.3 * PI * (i / num_directions) as f64;
-        let za = 0.3 + 0.4 * FRAC_PI_2 * (i / num_directions) as f64;
+        let az = 0.4 + 0.3 * PI * i as f64 / num_directions as f64;
+        let za = 0.3 + 0.4 * FRAC_PI_2 * i as f64 / num_directions as f64;
         azels.push(AzEl::from_radians(az, FRAC_PI_2 - za));
     }
 

--- a/src/analytic/ffi/mod.rs
+++ b/src/analytic/ffi/mod.rs
@@ -146,9 +146,8 @@ pub unsafe extern "C" fn analytic_calc_jones(
     let amps_s = slice::from_raw_parts(amps, num_amps as usize);
 
     // Using the passed-in beam, get the beam response (Jones matrix).
-    match beam.calc_jones_pair(
-        az_rad,
-        za_rad,
+    match beam.calc_jones(
+        (az_rad, za_rad),
         freq_hz,
         delays_s,
         amps_s,
@@ -243,9 +242,8 @@ pub unsafe extern "C" fn analytic_calc_jones_array(
     let amps_s = slice::from_raw_parts(amps, num_amps as usize);
     let results_s = slice::from_raw_parts_mut(jones.cast(), num_azza as usize);
 
-    ffi_error!(beam.calc_jones_array_pair_inner(
-        az,
-        za,
+    ffi_error!(beam.calc_jones_array_inner(
+        (az, za),
         freq_hz,
         delays_s,
         amps_s,

--- a/src/analytic/ffi/tests.rs
+++ b/src/analytic/ffi/tests.rs
@@ -301,9 +301,8 @@ fn test_calc_jones_gpu_via_ffi() {
         for (mut out, freq) in out.outer_iter_mut().zip(freqs) {
             unsafe {
                 let cpu_results = (*beam)
-                    .calc_jones_array_pair(
-                        &az,
-                        &za,
+                    .calc_jones_array(
+                        (&az, &za),
                         freq,
                         delays.as_slice().unwrap(),
                         amps.as_slice().unwrap(),

--- a/src/analytic/gpu/tests.rs
+++ b/src/analytic/gpu/tests.rs
@@ -47,9 +47,8 @@ fn test_analytic(
     {
         for (mut out, &freq) in out.outer_iter_mut().zip(freqs) {
             let cpu_results = beam
-                .calc_jones_array_pair(
-                    &az,
-                    &za,
+                .calc_jones_array(
+                    (&az, &za),
                     freq,
                     delays.as_slice().unwrap(),
                     amps.as_slice().unwrap(),
@@ -172,9 +171,8 @@ fn test_cram() {
 
     // Compare with CPU.
     let cpu_results = beam
-        .calc_jones_pair(
-            az_rad[0],
-            za_rad[0],
+        .calc_jones(
+            (az_rad[0], za_rad[0]),
             freq_hz[0],
             delays.as_slice().unwrap(),
             amps.as_slice().unwrap(),

--- a/src/analytic/mod.rs
+++ b/src/analytic/mod.rs
@@ -48,7 +48,8 @@ impl AnalyticType {
     }
 }
 
-/// The main struct to be used for calculating analytic pointings.
+/// The struct used to calculate beam-response Jones matrices for the analytic
+/// beam implementation.
 pub struct AnalyticBeam {
     /// The height of the MWA dipoles we're simulating \[metres\].
     ///

--- a/src/analytic/mod.rs
+++ b/src/analytic/mod.rs
@@ -21,7 +21,7 @@ use std::f64::consts::{FRAC_PI_2, TAU};
 use marlu::{c64, constants::VEL_C, rayon, AzEl, Jones};
 use rayon::prelude::*;
 
-use crate::constants::{DELAY_STEP, MWA_DPL_SEP};
+use crate::constants::{DELAY_STEP, MWA_DPL_HGT, MWA_DPL_HGT_RTS, MWA_DPL_SEP};
 
 #[cfg(any(feature = "cuda", feature = "hip"))]
 use ndarray::prelude::*;
@@ -42,8 +42,8 @@ impl AnalyticType {
     /// type.
     pub fn get_default_dipole_height(self) -> f64 {
         match self {
-            AnalyticType::MwaPb => 0.278,
-            AnalyticType::Rts => 0.30,
+            AnalyticType::MwaPb => MWA_DPL_HGT,
+            AnalyticType::Rts => MWA_DPL_HGT_RTS,
         }
     }
 }

--- a/src/analytic/tests.rs
+++ b/src/analytic/tests.rs
@@ -227,9 +227,8 @@ macro_rules! test_analytic {
             norm_to_zenith,
             expected,
         } = $args;
-        let result = $beam.calc_jones_pair(
-            az_rad,
-            za_rad,
+        let result = $beam.calc_jones(
+            (az_rad, za_rad),
             freq_hz,
             &delays,
             &amps,
@@ -278,9 +277,8 @@ fn mwa_pb_5() {
 #[test]
 fn mwa_pb_single_matches_array() {
     let beam = AnalyticBeam::new();
-    let result = beam.calc_jones_pair(
-        4.724779027649792,
-        0.3230075857,
+    let result = beam.calc_jones(
+        (4.724779027649792, 0.3230075857),
         200e6 as _,
         &[0, 2, 4, 6, 0, 1, 2, 3, 10, 12, 14, 16, 0, 4, 8, 12],
         &[1.0; 16],
@@ -290,9 +288,8 @@ fn mwa_pb_single_matches_array() {
     assert!(result.is_ok());
     let result = result.unwrap();
 
-    let result_a = beam.calc_jones_array_pair(
-        &[4.724779027649792],
-        &[0.3230075857],
+    let result_a = beam.calc_jones_array(
+        (&[4.724779027649792], &[0.3230075857]),
         200e6 as _,
         &[0, 2, 4, 6, 0, 1, 2, 3, 10, 12, 14, 16, 0, 4, 8, 12],
         &[1.0; 16],
@@ -339,9 +336,8 @@ fn rts_5() {
 #[test]
 fn rts_single_matches_array() {
     let beam = AnalyticBeam::new_rts();
-    let result = beam.calc_jones_pair(
-        4.724779027649792,
-        0.3230075857,
+    let result = beam.calc_jones(
+        (4.724779027649792, 0.3230075857),
         200e6 as _,
         &[0, 2, 4, 6, 0, 1, 2, 3, 10, 12, 14, 16, 0, 4, 8, 12],
         &[1.0; 16],
@@ -351,9 +347,8 @@ fn rts_single_matches_array() {
     assert!(result.is_ok());
     let result = result.unwrap();
 
-    let result_a = beam.calc_jones_array_pair(
-        &[4.724779027649792],
-        &[0.3230075857],
+    let result_a = beam.calc_jones_array(
+        (&[4.724779027649792], &[0.3230075857]),
         200e6 as _,
         &[0, 2, 4, 6, 0, 1, 2, 3, 10, 12, 14, 16, 0, 4, 8, 12],
         &[1.0; 16],
@@ -430,9 +425,8 @@ fn test_cram() {
     let norm_to_zenith = true;
 
     let beam = AnalyticBeam::new_custom(AnalyticType::MwaPb, 0.3, 8);
-    let result = beam.calc_jones_pair(
-        az_rad,
-        za_rad,
+    let result = beam.calc_jones(
+        (az_rad, za_rad),
         freq_hz,
         &delays,
         &amps,

--- a/src/bin/verify-beam-file.rs
+++ b/src/bin/verify-beam-file.rs
@@ -29,8 +29,14 @@ fn test_file(beam_file: &str) -> Result<(), InitFEEBeamError> {
     for &file_freq in beam.get_freqs() {
         println!("Testing freq {file_freq}");
         // If this blows up, we know there's a problem...
-        beam.calc_jones_pair(
-            0.0, 0.0, file_freq, &[0; 16], &[1.0; 16], false, None, false,
+        beam.calc_jones(
+            (0.0, 0.0),
+            file_freq,
+            &[0; 16],
+            &[1.0; 16],
+            false,
+            None,
+            false,
         )
         .unwrap();
     }

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -17,4 +17,10 @@ pub(crate) const J_POWER_TABLE: [c64; 4] = [
 ];
 
 /// MWA dipole separation \[metres\]
-pub(crate) const MWA_DPL_SEP: f64 = 1.100;
+pub const MWA_DPL_SEP: f64 = 1.100;
+
+/// MWA dipole height (according to mwa_pb) \[metres\]
+pub const MWA_DPL_HGT: f64 = 0.278;
+
+/// MWA dipole height (according to the RTS) \[metres\]
+pub const MWA_DPL_HGT_RTS: f64 = 0.30;

--- a/src/direction.rs
+++ b/src/direction.rs
@@ -1,0 +1,74 @@
+use std::f64::consts::FRAC_PI_2;
+
+use marlu::AzEl;
+
+/// A trait that describes a coordinate pair in a horizonal coordinate system.
+/// MWA beam codes historially specified (azimuth, zenith angle) rather than
+/// the perhaps-more-familiar "alt az" (altitude, azimuth), so we conform with
+/// history here. The MWA also prefers "elevation" instead of "altitude".
+pub trait HorizCoord: Copy {
+    /// Get the azimuth of this coordinate.
+    fn get_az(&self) -> f64;
+    /// Get the elevation of this coordinate.
+    fn get_el(&self) -> f64;
+    /// Get the zenith angle of this coordinate.
+    fn get_za(&self) -> f64;
+}
+
+impl<C: HorizCoord> HorizCoord for &C {
+    fn get_az(&self) -> f64 {
+        (*self).get_az()
+    }
+
+    fn get_el(&self) -> f64 {
+        (*self).get_el()
+    }
+
+    fn get_za(&self) -> f64 {
+        (*self).get_za()
+    }
+}
+
+impl HorizCoord for AzEl {
+    fn get_az(&self) -> f64 {
+        self.az
+    }
+
+    fn get_el(&self) -> f64 {
+        self.el
+    }
+
+    fn get_za(&self) -> f64 {
+        self.za()
+    }
+}
+
+/// We assume that a tuple of floats is (azimuth, zenith angle), both in
+/// radians.
+impl HorizCoord for (f64, f64) {
+    fn get_az(&self) -> f64 {
+        self.0
+    }
+
+    fn get_el(&self) -> f64 {
+        FRAC_PI_2 - self.1
+    }
+
+    fn get_za(&self) -> f64 {
+        self.1
+    }
+}
+
+impl HorizCoord for (&f64, &f64) {
+    fn get_az(&self) -> f64 {
+        *self.0
+    }
+
+    fn get_el(&self) -> f64 {
+        FRAC_PI_2 - self.1
+    }
+
+    fn get_za(&self) -> f64 {
+        *self.1
+    }
+}

--- a/src/fee/ffi/mod.rs
+++ b/src/fee/ffi/mod.rs
@@ -215,9 +215,8 @@ pub unsafe extern "C" fn fee_calc_jones(
     let amps_s = slice::from_raw_parts(amps, num_amps as usize);
 
     // Using the passed-in beam, get the beam response (Jones matrix).
-    match beam.calc_jones_pair(
-        az_rad,
-        za_rad,
+    match beam.calc_jones(
+        (az_rad, za_rad),
         freq_hz,
         delays_s,
         amps_s,
@@ -337,9 +336,8 @@ pub unsafe extern "C" fn fee_calc_jones_array(
     let amps_s = slice::from_raw_parts(amps, num_amps as usize);
     let results_s = slice::from_raw_parts_mut(jones.cast(), num_azza as usize);
 
-    ffi_error!(beam.calc_jones_array_pair_inner(
-        az,
-        za,
+    ffi_error!(beam.calc_jones_array_inner(
+        (az, za),
         freq_hz,
         delays_s,
         amps_s,

--- a/src/fee/ffi/tests.rs
+++ b/src/fee/ffi/tests.rs
@@ -361,9 +361,8 @@ fn test_calc_jones_gpu_via_ffi() {
         for (mut out, freq) in out.outer_iter_mut().zip(freqs) {
             unsafe {
                 let cpu_results = (*beam)
-                    .calc_jones_array_pair(
-                        &az,
-                        &za,
+                    .calc_jones_array(
+                        (&az, &za),
                         freq,
                         delays.as_slice().unwrap(),
                         amps.as_slice().unwrap(),

--- a/src/fee/gpu/tests.rs
+++ b/src/fee/gpu/tests.rs
@@ -7,6 +7,7 @@
 use approx::{assert_abs_diff_eq, assert_abs_diff_ne};
 use marlu::constants::MWA_LAT_RAD;
 use ndarray::prelude::*;
+use rayon::prelude::*;
 use serial_test::serial;
 
 use super::*;
@@ -55,9 +56,8 @@ fn test_gpu_calc_jones_no_norm() {
     {
         for (mut out, freq) in out.outer_iter_mut().zip(freqs) {
             let cpu_results = beam
-                .calc_jones_array_pair(
-                    &az,
-                    &za,
+                .calc_jones_array(
+                    (&az, &za),
                     freq,
                     delays.as_slice().unwrap(),
                     amps.as_slice().unwrap(),
@@ -127,9 +127,8 @@ fn test_gpu_calc_jones_w_norm() {
     {
         for (mut out, freq) in out.outer_iter_mut().zip(freqs) {
             let cpu_results = beam
-                .calc_jones_array_pair(
-                    &az,
-                    &za,
+                .calc_jones_array(
+                    (&az, &za),
                     freq,
                     delays.as_slice().unwrap(),
                     amps.as_slice().unwrap(),
@@ -199,9 +198,8 @@ fn test_gpu_calc_jones_w_norm_and_parallactic() {
     {
         for (mut out, freq) in out.outer_iter_mut().zip(freqs) {
             let cpu_results = beam
-                .calc_jones_array_pair(
-                    &az,
-                    &za,
+                .calc_jones_array(
+                    (&az, &za),
                     freq,
                     delays.as_slice().unwrap(),
                     amps.as_slice().unwrap(),
@@ -325,9 +323,8 @@ fn test_gpu_calc_jones_deduplication() {
     {
         for (mut out, freq) in out.outer_iter_mut().zip(freqs) {
             let cpu_results = beam
-                .calc_jones_array_pair(
-                    &az,
-                    &za,
+                .calc_jones_array(
+                    (&az, &za),
                     freq,
                     delays.as_slice().unwrap(),
                     amps.as_slice().unwrap(),
@@ -415,9 +412,8 @@ fn test_gpu_calc_jones_deduplication_w_norm() {
     {
         for (mut out, freq) in out.outer_iter_mut().zip(freqs) {
             let cpu_results = beam
-                .calc_jones_array_pair(
-                    &az,
-                    &za,
+                .calc_jones_array(
+                    (&az, &za),
                     freq,
                     delays.as_slice().unwrap(),
                     amps.as_slice().unwrap(),
@@ -495,9 +491,8 @@ fn test_gpu_calc_jones_no_amps() {
     {
         for (mut out, freq) in out.outer_iter_mut().zip(freqs.iter()) {
             let cpu_results = beam
-                .calc_jones_array_pair(
-                    &az,
-                    &za,
+                .calc_jones_array(
+                    (&az, &za),
                     *freq,
                     delays.as_slice().unwrap(),
                     amps.as_slice().unwrap(),

--- a/src/fee/mod.rs
+++ b/src/fee/mod.rs
@@ -2,8 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-//! Code to implement the MWA Fully Embedded Element (FEE) beam, a.k.a. "the
-//! 2016 beam".
+//! Code for the MWA Fully Embedded Element (FEE) beam, a.k.a. "the 2016 beam".
 
 mod error;
 mod ffi;
@@ -37,7 +36,8 @@ use crate::{
     types::{CacheKey, Pol},
 };
 
-/// The main struct to be used for calculating Jones matrices.
+/// The struct used to calculate beam-response Jones matrices for the Fully
+/// Embedded Element (FEE) beam, a.k.a. "the 2016 beam".
 #[allow(clippy::upper_case_acronyms)]
 pub struct FEEBeam {
     /// The [`hdf5_metno::File`] struct associated with the opened HDF5 file. It is

--- a/src/fee/tests.rs
+++ b/src/fee/tests.rs
@@ -575,9 +575,8 @@ fn test_get_modes2() {
 #[serial]
 fn test_calc_jones_eng() {
     let beam = FEEBeam::new("mwa_full_embedded_element_pattern.h5").unwrap();
-    let result = beam.calc_jones_pair(
-        45.0_f64.to_radians(),
-        10.0_f64.to_radians(),
+    let result = beam.calc_jones(
+        (45.0_f64.to_radians(), 10.0_f64.to_radians()),
         51200000,
         &[0; 16],
         &[1.0; 16],
@@ -601,9 +600,8 @@ fn test_calc_jones_eng() {
 #[serial]
 fn test_calc_jones_eng_2() {
     let beam = FEEBeam::new("mwa_full_embedded_element_pattern.h5").unwrap();
-    let result = beam.calc_jones_pair(
-        70.0_f64.to_radians(),
-        10.0_f64.to_radians(),
+    let result = beam.calc_jones(
+        (70.0_f64.to_radians(), 10.0_f64.to_radians()),
         51200000,
         &[3, 2, 1, 0, 3, 2, 1, 0, 3, 2, 1, 0, 3, 2, 1, 0],
         &[
@@ -629,8 +627,14 @@ fn test_calc_jones_eng_2() {
 #[serial]
 fn test_calc_jones_eng_norm() {
     let beam = FEEBeam::new("mwa_full_embedded_element_pattern.h5").unwrap();
-    let result = beam.calc_jones_pair(
-        0.1_f64, 0.1_f64, 150000000, &[0; 16], &[1.0; 16], true, None, false,
+    let result = beam.calc_jones(
+        (0.1_f64, 0.1_f64),
+        150000000,
+        &[0; 16],
+        &[1.0; 16],
+        true,
+        None,
+        false,
     );
     assert!(result.is_ok());
     let jones = result.unwrap();
@@ -648,9 +652,8 @@ fn test_calc_jones_eng_norm() {
 #[serial]
 fn test_calc_jones_eng_norm_2() {
     let beam = FEEBeam::new("mwa_full_embedded_element_pattern.h5").unwrap();
-    let result = beam.calc_jones_pair(
-        0.1_f64,
-        0.1_f64,
+    let result = beam.calc_jones(
+        (0.1_f64, 0.1_f64),
         150000000,
         &[3, 2, 1, 0, 3, 2, 1, 0, 3, 2, 1, 0, 3, 2, 1, 0],
         &[
@@ -676,9 +679,8 @@ fn test_calc_jones_eng_norm_2() {
 #[serial]
 fn test_calc_jones() {
     let beam = FEEBeam::new("mwa_full_embedded_element_pattern.h5").unwrap();
-    let result = beam.calc_jones_pair(
-        45.0_f64.to_radians(),
-        10.0_f64.to_radians(),
+    let result = beam.calc_jones(
+        (45.0_f64.to_radians(), 10.0_f64.to_radians()),
         51200000,
         &[0; 16],
         &[1.0; 16],
@@ -702,9 +704,8 @@ fn test_calc_jones() {
 #[serial]
 fn test_calc_jones_norm() {
     let beam = FEEBeam::new("mwa_full_embedded_element_pattern.h5").unwrap();
-    let result = beam.calc_jones_pair(
-        0.1_f64,
-        0.1_f64,
+    let result = beam.calc_jones(
+        (0.1_f64, 0.1_f64),
         150000000,
         &[0; 16],
         &[1.0; 16],
@@ -742,9 +743,8 @@ fn test_calc_jones_norm() {
 #[serial]
 fn test_calc_jones_pa() {
     let beam = FEEBeam::new("mwa_full_embedded_element_pattern.h5").unwrap();
-    let result = beam.calc_jones_pair(
-        0.1_f64,
-        0.1_f64,
+    let result = beam.calc_jones(
+        (0.1_f64, 0.1_f64),
         150000000,
         &[0; 16],
         &[1.0; 16],
@@ -755,8 +755,14 @@ fn test_calc_jones_pa() {
     assert!(result.is_ok());
     let pa = result.unwrap();
 
-    let result = beam.calc_jones_pair(
-        0.1_f64, 0.1_f64, 150000000, &[0; 16], &[1.0; 16], true, None, false,
+    let result = beam.calc_jones(
+        (0.1_f64, 0.1_f64),
+        150000000,
+        &[0; 16],
+        &[1.0; 16],
+        true,
+        None,
+        false,
     );
     assert!(result.is_ok());
     let not_pa = result.unwrap();
@@ -768,9 +774,8 @@ fn test_calc_jones_pa() {
 #[serial]
 fn test_calc_jones_iau() {
     let beam = FEEBeam::new("mwa_full_embedded_element_pattern.h5").unwrap();
-    let result = beam.calc_jones_pair(
-        0.1_f64,
-        0.1_f64,
+    let result = beam.calc_jones(
+        (0.1_f64, 0.1_f64),
         150000000,
         &[0; 16],
         &[1.0; 16],
@@ -781,9 +786,8 @@ fn test_calc_jones_iau() {
     assert!(result.is_ok());
     let j_iau = result.unwrap();
 
-    let result = beam.calc_jones_pair(
-        0.1_f64,
-        0.1_f64,
+    let result = beam.calc_jones(
+        (0.1_f64, 0.1_f64),
         150000000,
         &[0; 16],
         &[1.0; 16],
@@ -808,9 +812,10 @@ fn test_calc_jones_iau() {
 #[serial]
 fn test_calc_jones_array() {
     let beam = FEEBeam::new("mwa_full_embedded_element_pattern.h5").unwrap();
-    let result = beam.calc_jones_pair(
-        45.0_f64.to_radians(),
-        10.0_f64.to_radians(),
+    let az = 45.0_f64.to_radians();
+    let za = 10.0_f64.to_radians();
+    let result = beam.calc_jones(
+        (az, za),
         51200000,
         &[0; 16],
         &[1.0; 16],
@@ -821,9 +826,8 @@ fn test_calc_jones_array() {
     assert!(result.is_ok());
     let jones = result.unwrap();
 
-    let result = beam.calc_jones_array_pair(
-        &[45.0_f64.to_radians()],
-        &[10.0_f64.to_radians()],
+    let result = beam.calc_jones_array(
+        (&[az], &[za]),
         51200000,
         &[0; 16],
         &[1.0; 16],
@@ -837,10 +841,9 @@ fn test_calc_jones_array() {
     assert_eq!(jones_array.len(), 1);
     assert_eq!(jones, jones_array[0]);
 
-    // Ensure that FEEBeam::calc_jones_array is the same as
-    // FEEBeam::calc_jones_array_pair.
+    // Ensure that using `AzEl` gives the same results as above.
     let result = beam.calc_jones_array(
-        &[AzEl::from_degrees(45.0, 80.0)],
+        [AzEl::from_radians(az, FRAC_PI_2 - za)],
         51200000,
         &[0; 16],
         &[1.0; 16],
@@ -858,9 +861,8 @@ fn test_calc_jones_array() {
 #[serial]
 fn test_empty_cache() {
     let beam = FEEBeam::new("mwa_full_embedded_element_pattern.h5").unwrap();
-    let result = beam.calc_jones_pair(
-        45.0_f64.to_radians(),
-        10.0_f64.to_radians(),
+    let result = beam.calc_jones(
+        (45.0_f64.to_radians(), 10.0_f64.to_radians()),
         51200000,
         &[0; 16],
         &[1.0; 16],
@@ -893,9 +895,8 @@ fn test_get_freqs() {
 #[serial]
 fn test_cache_is_used() {
     let beam = FEEBeam::new("mwa_full_embedded_element_pattern.h5").unwrap();
-    let result = beam.calc_jones_pair(
-        45.0_f64.to_radians(),
-        10.0_f64.to_radians(),
+    let result = beam.calc_jones(
+        (45.0_f64.to_radians(), 10.0_f64.to_radians()),
         51200000,
         &[0; 16],
         &[1.0; 16],
@@ -906,9 +907,8 @@ fn test_cache_is_used() {
     assert!(result.is_ok());
     result.unwrap();
 
-    let result = beam.calc_jones_pair(
-        45.0_f64.to_radians(),
-        10.0_f64.to_radians(),
+    let result = beam.calc_jones(
+        (45.0_f64.to_radians(), 10.0_f64.to_radians()),
         51200000,
         &[0; 16],
         &[1.0; 16],

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -5,7 +5,7 @@
 //! General FFI code for error handling.
 //!
 //! Most of this is derived from
-//! <https://michael-f-bryan.github.io/rust-ffi-guide/errors/return_types.html
+//! <https://michael-f-bryan.github.io/rust-ffi-guide/errors/return_types.html>
 
 use std::{
     cell::RefCell,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,12 +16,16 @@ mod types;
 mod python;
 
 // Re-exports.
+pub use analytic::AnalyticBeam;
+pub use fee::FEEBeam;
 cfg_if::cfg_if! {
     if #[cfg(any(feature = "cuda", feature = "hip"))] {
         mod gpu;
         /// The float type used in GPU code. This depends on how `hyperbeam` was
         /// compiled (used cargo feature "gpu-single" or not).
         pub use gpu::{GpuFloat, GpuComplex};
+        pub use analytic::AnalyticBeamGpu;
+        pub use fee::FEEBeamGpu;
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
 //! Primary beam code for the Murchison Widefield Array.
 
 pub mod analytic;
-mod constants;
+pub mod constants;
 mod factorial;
 pub mod fee;
 mod ffi;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@
 
 pub mod analytic;
 pub mod constants;
+mod direction;
 mod factorial;
 pub mod fee;
 mod ffi;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ mod python;
 cfg_if::cfg_if! {
     if #[cfg(any(feature = "cuda", feature = "hip"))] {
         mod gpu;
-        /// The float type use in GPU code. This depends on how `hyperbeam` was
+        /// The float type used in GPU code. This depends on how `hyperbeam` was
         /// compiled (used cargo feature "gpu-single" or not).
         pub use gpu::{GpuFloat, GpuComplex};
     }

--- a/src/python/analytic.rs
+++ b/src/python/analytic.rs
@@ -68,9 +68,8 @@ impl AnalyticBeam {
         latitude_rad: f64,
         norm_to_zenith: Option<bool>,
     ) -> PyResult<Bound<'py, PyArray1<c64>>> {
-        let jones = self.beam.calc_jones_pair(
-            az_rad,
-            za_rad,
+        let jones = self.beam.calc_jones(
+            (az_rad, za_rad),
             // hyperbeam expects an int for the frequency. By specifying that
             // Python should pass in a float, it also allows an int to be passed
             // in (!?). Convert the float here in Rust for usage in hyperbeam.
@@ -106,9 +105,8 @@ impl AnalyticBeam {
         latitude_rad: f64,
         norm_to_zenith: Option<bool>,
     ) -> PyResult<Bound<'py, PyArray2<c64>>> {
-        let jones = self.beam.calc_jones_array_pair(
-            &az_rad,
-            &za_rad,
+        let jones = self.beam.calc_jones_array(
+            (&az_rad, &za_rad),
             freq_hz.round() as _,
             &delays,
             &amps,

--- a/src/python/fee.rs
+++ b/src/python/fee.rs
@@ -10,6 +10,7 @@ use self::ndarray::prelude::*;
 use num_complex::Complex64 as c64;
 use numpy::*;
 use pyo3::prelude::*;
+use rayon::prelude::*;
 
 use crate::fee::FEEBeam as FEEBeamRust;
 #[cfg(any(feature = "cuda", feature = "hip"))]
@@ -79,9 +80,8 @@ impl FEEBeam {
         latitude_rad: Option<f64>,
         iau_order: Option<bool>,
     ) -> PyResult<Bound<'py, PyArray1<c64>>> {
-        let jones = self.beam.calc_jones_pair(
-            az_rad,
-            za_rad,
+        let jones = self.beam.calc_jones(
+            (az_rad, za_rad),
             // hyperbeam expects an int for the frequency. By specifying that
             // Python should pass in a float, it also allows an int to be passed
             // in (!?). Convert the float here in Rust for usage in hyperbeam.
@@ -124,9 +124,8 @@ impl FEEBeam {
         latitude_rad: Option<f64>,
         iau_order: Option<bool>,
     ) -> PyResult<Bound<'py, PyArray2<c64>>> {
-        let jones = self.beam.calc_jones_array_pair(
-            &az_rad,
-            &za_rad,
+        let jones = self.beam.calc_jones_array(
+            (&az_rad, &za_rad),
             freq_hz.round() as _,
             &delays,
             &amps,


### PR DESCRIPTION
Note that only the last commit in this PR is a breaking change; let me know if you want me to split it.

The last commit allows users to call the "calc beam" functions with anything we recognise as a "direction". Before this commit, there were two functions to allow (1) an AzEl or (2) a tuple of floats. With the generic approach, only a single function is needed; this is much tidier and could possibly be extended in the future.

I freely admit that I needed help with understanding the generics. You can see the discussion here: https://users.rust-lang.org/t/make-a-new-iterator-trait-to-replace-d-or-f64-f64/126644

Also, don't feel like this work _has_ to be merged; I'm mostly doing this because I felt like this approach should've been there from the start, but I wasn't good enough/didn't have time to implement it. And now I'm a little bored and find myself missing Rust 🥲 