### PR TITLE
Fix aarch64 wheels returning zeros by using valid target-cpu (#19)

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -44,7 +44,7 @@ jobs:
         uses: taiki-e/install-action@cargo-llvm-cov
 
       - name: Get the HDF5 file
-        run: curl http://ws.mwatelescope.org/static/mwa_full_embedded_element_pattern.h5 -o mwa_full_embedded_element_pattern.h5
+        run: curl -L http://ws.mwatelescope.org/static/mwa_full_embedded_element_pattern.h5 -o mwa_full_embedded_element_pattern.h5
 
       - name: Generate code coverage
         run: cargo llvm-cov --workspace --lcov --output-path lcov.info

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -72,7 +72,7 @@ jobs:
       - name: test docker image
         run: |
           docker run --rm ${{ env.REGISTRY_IMAGE }}@${{ steps.build.outputs.digest }} /bin/bash -c "\
-            curl http://ws.mwatelescope.org/static/mwa_full_embedded_element_pattern.h5 -o mwa_full_embedded_element_pattern.h5 && \
+            curl -L http://ws.mwatelescope.org/static/mwa_full_embedded_element_pattern.h5 -o mwa_full_embedded_element_pattern.h5 && \
             cargo test --release"
 
   merge:

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -1,11 +1,14 @@
 ---
 name: Release
 
-# Do this on every tagged commit
+# Build and test on all pushes and pull requests, but only publish on tagged commits
 on:
   push:
+    branches:
+      - '**'
     tags:
       - "v*"
+  pull_request:
 
 env:
   CARGO_TERM_COLOR: always
@@ -89,8 +92,8 @@ jobs:
 
         # Because we've compiled HDF5 and ERFA into hyperbeam products, we
         # legally must distribute their licenses with the products.
-        curl https://raw.githubusercontent.com/HDFGroup/hdf5/develop/COPYING -o COPYING-hdf5
-        curl https://raw.githubusercontent.com/liberfa/erfa/master/LICENSE -o LICENSE-erfa
+        curl -L https://raw.githubusercontent.com/HDFGroup/hdf5/develop/COPYING -o COPYING-hdf5
+        curl -L https://raw.githubusercontent.com/liberfa/erfa/master/LICENSE -o LICENSE-erfa
 
         export TAG="$(git describe --tags)"
         export VER="v$(grep version Cargo.toml -m1 | cut -d' ' -f3 | tr -d '"')"
@@ -108,7 +111,7 @@ jobs:
             fi
             ;;
           arm64) export TARGETS="apple-m1" ;;
-          aarch64) export TARGETS="aarch64" ;;
+          aarch64) export TARGETS="generic" ;;
           *) echo "unknown arch (uname -m) $ARCH"; exit 1 ;;
         esac
 
@@ -148,10 +151,68 @@ jobs:
         path: "*.tar.gz"
         if-no-files-found: error
 
+    - name: Test Python wheels
+      run: |
+        # Download the HDF5 file
+        curl -L http://ws.mwatelescope.org/static/mwa_full_embedded_element_pattern.h5 -o mwa_full_embedded_element_pattern.h5
+        
+        # Test each wheel with the matching Python version
+        for whl in *.whl; do
+          echo "Testing wheel: $whl"
+          
+          # Extract Python version from wheel name (e.g., cp310 -> 3.10)
+          if [[ $whl =~ cp([0-9])([0-9]+) ]]; then
+            py_major="${BASH_REMATCH[1]}"
+            py_minor="${BASH_REMATCH[2]}"
+            py_version="${py_major}.${py_minor}"
+            
+            # Check if this Python version is available
+            if ! command -v "python${py_version}" &> /dev/null; then
+              echo "Python ${py_version} not available, skipping wheel test"
+              continue
+            fi
+            
+            echo "Using Python ${py_version} for wheel $whl"
+            "python${py_version}" -m venv test_venv
+            . test_venv/bin/activate
+            pip install --upgrade pip
+            pip install numpy "$whl"
+            
+            # Test that calc_jones returns non-zero values
+            cat > test_wheel.py << 'PYTEST'
+        import numpy as np
+        from mwa_hyperbeam import FEEBeam
+        
+        beam = FEEBeam('mwa_full_embedded_element_pattern.h5')
+        J = beam.calc_jones_array(
+            np.array([0.0]),
+            np.array([0.0]),
+            181e6,
+            [0]*16,
+            [1]*16,
+            True
+        )
+        result = float(abs(J[0,0])**2)
+        print(f'Result: {result}')
+        assert result > 0.0, f'Expected non-zero result, got {result}'
+        print('✓ Test passed: calc_jones returned non-zero value')
+        PYTEST
+            
+            python test_wheel.py
+            rm test_wheel.py
+            
+            deactivate
+            rm -rf test_venv
+          else
+            echo "Could not determine Python version from wheel name: $whl"
+          fi
+        done
+
   create-rust-release:
     name: Publish to crates.io
     runs-on: ubuntu-latest
     needs: [build-release]
+    if: startsWith(github.ref, 'refs/tags/v')
     environment: CI
     steps:
       - name: Checkout sources
@@ -177,6 +238,7 @@ jobs:
     name: Create a new github and pypi release
     runs-on: ubuntu-latest
     needs: [create-rust-release]
+    if: startsWith(github.ref, 'refs/tags/v')
     environment: CI
     steps:
       - name: Download all artifacts

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -74,7 +74,7 @@ jobs:
           ! grep -i gpu include/mwa_hyperbeam.h
 
       - name: Get the HDF5 file
-        run: curl http://ws.mwatelescope.org/static/mwa_full_embedded_element_pattern.h5 -o mwa_full_embedded_element_pattern.h5
+        run: curl -L http://ws.mwatelescope.org/static/mwa_full_embedded_element_pattern.h5 -o mwa_full_embedded_element_pattern.h5
 
       # Taken from https://github.com/dtolnay/thiserror/blob/a2d1ed1ccfc2a5dbb2a8fb45d4f938175a28bc86/.github/workflows/ci.yml
       - name: Enable type layout randomization

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ mwa_full_embedded_element_pattern.h5
 /examples/fee_parallel
 /examples/fee_parallel_omp
 /examples/get_freqs
+*.rlib

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.10.3] - 2025-10-14
 
 ### Fixed
 
@@ -15,7 +15,6 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ## [0.10.2] - 2025-04-11
 
 - ⬆️ mwalib v1.8.7, marlu v0.16.1
-
 
 ## [0.10.1] - 2025-01-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- fix #18: aarch64 wheels now return correct values instead of zeros. The build was using an invalid target-cpu value ("aarch64") which caused incorrect code generation. Changed to use "generic" which is the correct default target-cpu for aarch64 builds.
+
 ## [0.10.2] - 2025-04-11
 
 - ⬆️ mwalib v1.8.7, marlu v0.16.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "mwa_hyperbeam"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "approx",
  "cbindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mwa_hyperbeam"
-version = "0.10.2"
+version = "0.10.3"
 authors = [
     "Christopher H. Jordan <christopherjordan87@gmail.com>",
     "Jack L. B. Line <jack.line@curtin.edu.au>",

--- a/src/legendre.rs
+++ b/src/legendre.rs
@@ -160,7 +160,7 @@ pub(crate) fn p1sin(n_max: u8, theta: f64) -> (Vec<f64>, Vec<f64>) {
         let ind_stop = n * n + 2 * n;
         for i in ind_start..ind_stop {
             let index = i - ind_start;
-            let j = if index < n { n - index } else { index - n };
+            let j = n.abs_diff(index);
             p1sin_out[i] = pm_sin[j];
             p1_out[i] = pm1[j];
         }


### PR DESCRIPTION
- Fix aarch64 wheel returning zeros by using generic target-cpu
- Fix clippy lint: use abs_diff instead of manual pattern
- Add -L to curl commands and refactor releases workflow
- Refactor releases workflow to always build and test, but only publish on tags
- Add Python wheel tests that verify calc_jones returns non-zero values